### PR TITLE
Fix flex-box for Safari

### DIFF
--- a/sass/_flexbox.scss
+++ b/sass/_flexbox.scss
@@ -5,6 +5,25 @@
   justify-content: center;
   align-content: center;
   align-items: center;
+
+
+  display: -webkit-box;
+  display: -moz-box;
+  display: -o-flex;
+  display: -webkit-flex;
+  display: flex;
+  -moz-flex-direction: row;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -moz-flex-flow: row wrap;
+  -webkit-flex-wrap: nowrap;
+  flex-wrap: wrap;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  align-content: center;
+  -webkit-align-items: center;
+  align-items: center;
 }
 
 %flex-container-media {
@@ -14,8 +33,10 @@
   display: -webkit-flex;
   display: flex;
   -moz-flex-direction: row;
+  -webkit-flex-direction: row;
   flex-direction: row;
   -moz-flex-flow: row wrap;
+  -webkit-flex-wrap: nowrap;
   flex-wrap: wrap;
   -webkit-justify-content: center;
   justify-content: center;
@@ -23,23 +44,27 @@
   align-content: center;
   -webkit-align-items: center;
   align-items: center;
-  -webkit-flex-flow: row wrap;
-      flex-flow: row wrap;
 }
 
 %flex-item {
   text-align: center;
   margin: auto;
   max-width: 85%;
+  -webkit-flex-basis: 85%;
+  flex-basis: 85%;
   padding-top: 2.5%;
   padding-bottom: 2.5%;
+
+    -webkit-flex: 0 1 auto;
+    -ms-flex: 0 1 auto;
+    flex: 0 1 auto;
 }
 
 .l-flex-container {
   @extend %flex-container;
 
   @media only screen and (min-width: $break) {
-    @extend %flex-container-media;
+    //@extend %flex-container-media;
 
     &[data-flex-container="services-one"] {
       -webkit-flex-flow: row wrap;
@@ -69,6 +94,9 @@
 
     [data-flex-container="about"] & {
       max-width: 40%;
+        -webkit-flex-basis: 40%;
+  flex-basis: 40%;
+
       padding-bottom: 5%;
     }
 
@@ -78,8 +106,14 @@
 
     [data-flex-container="services-one"] & {
       max-width: 40%;
+        -webkit-flex-basis: 40%;
+  flex-basis: 40%;
+
       &.svcs-intro {
         max-width: 85%;
+          -webkit-flex-basis: 85%;
+  flex-basis: 85%;
+
       }
     }
 


### PR DESCRIPTION
Your `%flex-container` class did not have any vendor prefixes; be sure
to use prefixes anywhere you use flex-box properties.

Also for sizing flex items, you want to use the `flex-basis` property,
not just width. Use width as a fallback. And be sure to prefix it.

@chrisdholt @jimmynono 